### PR TITLE
Add deep_copy calls missing because of a Y2R bug

### DIFF
--- a/src/include/iscsi-lio-server/widgets.rb
+++ b/src/include/iscsi-lio-server/widgets.rb
@@ -281,7 +281,9 @@ module Yast
     def LUNDetailDialog(pos, items)
       items = deep_copy(items)
       Builtins.y2milestone("LUNDetailDialog pos:%1 items:%2", pos, items)
-      other = Ops.greater_or_equal(pos, 0) ? Builtins.remove(items, pos) : items
+      other = Ops.greater_or_equal(pos, 0) ?
+        Builtins.remove(items, pos) :
+        deep_copy(items)
       Builtins.y2milestone("LUNDetailDialog other:%1", other)
       previous = Ops.get(items, pos, Empty())
       ret = Empty()


### PR DESCRIPTION
See https://github.com/yast/y2r/issues/47.
