### PR TITLE
it is a fix for BSC#932170

### DIFF
--- a/src/include/iscsi-lio-server/widgets.rb
+++ b/src/include/iscsi-lio-server/widgets.rb
@@ -1180,11 +1180,19 @@ module Yast
       option_map = deep_copy(option_map)
       target = uiTarget
       Builtins.y2milestone("storeAddTarget %1", target)
+      if Builtins.isempty(Ops.get_string(target, 1, ""))
+       @curr_target = Builtins.sformat(
+        "%1%2",
+        Ops.get_string(target, 0, ""),
+        Ops.get_string(target, 1, "")
+      )
+      else
       @curr_target = Builtins.sformat(
         "%1:%2",
         Ops.get_string(target, 0, ""),
         Ops.get_string(target, 1, "")
       )
+      end
       @curr_tpg = Ops.get_integer(target, 2, -1)
       storeModify(option_id, option_map)
 


### PR DESCRIPTION
It is a bug fix for https://bugzilla.suse.com/show_bug.cgi?id=932170

Bug 932170 - yast2-iscsi-lio-server would add a ":" to target name even leaving the identifier empty when create a target