### PR TITLE
It is a bug fix for BNC#933564, yast did not describe initiator acls …

### DIFF
--- a/src/include/iscsi-lio-server/dialogs.rb
+++ b/src/include/iscsi-lio-server/dialogs.rb
@@ -190,7 +190,7 @@ module Yast
                 ),
                 Table(
                   Id(:clnt_table),
-                  Header(_("Client"), _("Lun Mapping"), _("Auth")),
+                  Header(_("Initiator"), _("Lun Mapping"), _("Auth")),
                   []
                 ),
                 Left(
@@ -504,7 +504,7 @@ module Yast
     # discovery authentication dialog
     def AuthDialog
       @current_tab = "targets"
-      caption = _("Modify iSCSI Target Client Setup")
+      caption = _("Modify iSCSI Initiator ACLs Setup")
       w = CWM.CreateWidgets(["target-clnt"], @widgets)
       contents = VBox(
         VStretch(),

--- a/src/include/iscsi-lio-server/helps.rb
+++ b/src/include/iscsi-lio-server/helps.rb
@@ -122,10 +122,10 @@ module Yast
         ),
         # target client setup.
         "target-clnt"        => _(
-           "<p>Use <b>Add</b> to give a client access for a LUN imported from target portal group." +
-           " Specify which client is allowed to access it (client name is <i>InitiatorName</i> in" +
+           "<p>Use <b>Add</b> to give a Initiator access for a LUN imported from target portal group." +
+           " Specify which Initiator is allowed to access it (client name is <i>InitiatorName</i> in" +
            " '/etc/iscsi/initiatorname.iscsi' on iscsi initiator). <b>Delete</b> will remove the" +
-           " client access to the LUN.</p>"
+           " Initiator access to the LUN.</p>"
          ) +
           _(
             "<p>With <b>Edit LUN</b> one can modify the LUN mapping. Please note that LUN target number" +
@@ -133,7 +133,7 @@ module Yast
             " Use <b>Incoming</b>, <b>Outgoing</b> or both together. Then insert <b>User</b> and <b>Password</b>." +
             " If <b>Use Authentication</b> is disabled in previous dialog, <b>Edit Auth</b> is disabled here.</p>"
           ) +
-        _( "<p><b>Copy</b> offers the possibility to give an additional client access to the LUN.</p>"),
+        _( "<p><b>Copy</b> offers the possibility to give an additional initiator access to the LUN.</p>"),
         # target dialog
         "server_table"       => _(
           "List of offered targets and target portal groups. Create a new target by clicking <b>Add</b>.\n" +

--- a/src/include/iscsi-lio-server/widgets.rb
+++ b/src/include/iscsi-lio-server/widgets.rb
@@ -433,7 +433,7 @@ module Yast
           Table(
             Id(:lun),
             Opt(:keepSorting, :immediate, :notify, :notifyContextMenu),
-            Header(_("Client Lun"), _("Target LUN")),
+            Header(_("Initiator Lun"), _("Target LUN")),
             items
           )
         ),
@@ -616,7 +616,7 @@ module Yast
           4,
           1,
           VBox(
-            Left(Label(_("Client name:"))),
+            Left(Label(_("Initiator name:"))),
             MinWidth(50, InputField(Id(:clnt), Opt(:hstretch), "", "")),
             VSpacing(0.5),
             Left(CheckBox(Id(:import), _("Import LUNs from TPG"), true))
@@ -635,15 +635,15 @@ module Yast
         if sym == :ok
           txt = ""
           s = Convert.to_string(UI.QueryWidget(Id(:clnt), :Value))
-          txt = _("Client name must not be empty!") if Builtins.isempty(s)
-          Builtins.y2milestone("Changed_lun: %1 new client name: %2", @changed_lun, s)
+          txt = _("Initiator name must not be empty!") if Builtins.isempty(s)
+          Builtins.y2milestone("Changed_lun: %1 new initiator name: %2", @changed_lun, s)
           # Don't check IscsiLioData.GetClntList(@curr_target, @curr_tpg) for existing
           # client name. It's allowed to have several LUNs accessable for same client.
           # TODO: verify whether it's necessary to check @changed_lun here?
           if @changed_lun.has_key?(s)
-            txt = _("Client name already exists!")
+            txt = _("Initiator name already exists!")
           end
-          # TODO: check client name for valid chars (depends on solution for fate #318406)
+          # TODO: check initiator name for valid chars (depends on solution for fate #318406)
           if !Builtins.isempty(txt)
             sym = :again
             UI.SetFocus(Id(:clnt))
@@ -664,7 +664,7 @@ module Yast
     end
 
     #
-    # Copy exisiting LUN, i.e. give additional client access to the LUN
+    # Copy exisiting LUN, i.e. give additional initiator access to the LUN
     # (which is allowed, makes sense e.g. with multipath)
     #
     def CopyClntDialog
@@ -675,7 +675,7 @@ module Yast
           4,
           1,
           VBox(
-            Left(Label(_("New client name:"))),
+            Left(Label(_("New initiator name:"))),
             MinWidth(50, InputField(Id(:clnt), Opt(:hstretch), "", ""))
           )
         ),
@@ -692,13 +692,13 @@ module Yast
         if sym == :ok
           txt = ""
           s = Convert.to_string(UI.QueryWidget(Id(:clnt), :Value))
-          txt = _("Client name must not be empty!") if Builtins.isempty(s)
+          txt = _("Initiator name must not be empty!") if Builtins.isempty(s)
           if Builtins.haskey(@changed_lun, s) ||
               Builtins.contains(
                 IscsiLioData.GetClntList(@curr_target, @curr_tpg),
                 s
               )
-            txt = _("Client name already exists!")
+            txt = _("Initiator name already exists!")
           end
           if !Builtins.isempty(txt)
             sym = :again
@@ -1287,7 +1287,7 @@ module Yast
             if del != nil
               if Popup.ContinueCancel(_("Really delete the selected item?"))
                 Builtins.y2milestone(
-                  "handleClient Delete Client %1 from table",
+                  "handleClient Delete Initiator %1 from table",
                   del
                 )
                 it = Convert.convert(
@@ -1447,11 +1447,11 @@ module Yast
 
       if !clients.nil? && clients.empty?
         continue = Popup.YesNoHeadline( Label.WarningMsg,
-                                        _("There isn't any client specified.\n" +
-                                        "To allow a client login to the target, please\n" +
+                                        _("There isn't any initiator specified.\n" +
+                                        "To allow a initiator login to the target, please\n" +
                                         "use the 'Add' button and enter the name\n" +
                                         "(see /etc/iscsi/initiatorname.iscsi on initiator).\n" +
-                                        "Really want to continue without client access?"
+                                        "Really want to continue without initiators access?"
                                         ))
       end
       continue
@@ -1461,7 +1461,7 @@ module Yast
       ret = IscsiLioData.DoRemoveClntLun(tgt, tpg, clnt, lun)
       if !ret
         txt = Builtins.sformat(
-          _("Problem removing lun %4 for client %3 in %1:%2"),
+          _("Problem removing lun %4 for initiator %3 in %1:%2"),
           tgt,
           tpg,
           clnt,
@@ -1476,7 +1476,7 @@ module Yast
       ret = IscsiLioData.DoCreateClntLun(tgt, tpg, clnt, lun, tlun)
       if !ret
         txt = Builtins.sformat(
-          _("Problem adding lun %4:%5 for client %3 in %1:%2"),
+          _("Problem adding lun %4:%5 for initiator %3 in %1:%2"),
           tgt,
           tpg,
           clnt,
@@ -1497,7 +1497,7 @@ module Yast
           chg = true
           if !IscsiLioData.DoRemoveClnt(@curr_target, @curr_tpg, c)
             txt = Builtins.sformat(
-              _("Problem removing client %3 from %1:%2"),
+              _("Problem removing initiator %3 from %1:%2"),
               @curr_target,
               @curr_tpg,
               c
@@ -1521,7 +1521,7 @@ module Yast
         chg = true
         if !IscsiLioData.DoCreateClnt(@curr_target, @curr_tpg, c)
           txt = Builtins.sformat(
-            _("Problem creating client %3 for %1:%2"),
+            _("Problem creating initiator %3 for %1:%2"),
             @curr_target,
             @curr_tpg,
             c
@@ -1546,7 +1546,7 @@ module Yast
                 Ops.get_string(ca, ["outgoing", 0], "") ||
               Ops.get_string(m, ["outgoing", 1], "") !=
                 Ops.get_string(ca, ["outgoing", 1], "")
-            Builtins.y2milestone("storeClient set auth for client:%1", c)
+            Builtins.y2milestone("storeInitiator set auth for client:%1", c)
             chg = true
             if !IscsiLioData.SetAuth(
                 @curr_target,
@@ -1556,7 +1556,7 @@ module Yast
                 Ops.get_list(m, "outgoing", [])
               )
               txt = Builtins.sformat(
-                _("Problem changing auth for client %3 in %1:%2"),
+                _("Problem changing auth for initiator %3 in %1:%2"),
                 @curr_target,
                 @curr_tpg,
                 c


### PR DESCRIPTION
It is a bug fix for BNC#933564, it is not a functional bug, but no one can understand when show a dialog titled with "Modify ISCSI Target Client setup". It meant to define a access control for the initiators. In iSCSI, we call the client "Initiator"