### PR TITLE
It is a bug fix for BNC#936990

### DIFF
--- a/package/yast2-iscsi-lio-server.changes
+++ b/package/yast2-iscsi-lio-server.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Tue Jul 14 17:08:40 CET 2015 - lszhu@suse.de
+
+- set demo_mode, disable authentication, disable write protection
+  when no authentication(bnc#936990)
+- 3.16
+
+-------------------------------------------------------------------
 Wed May 27 15:45:03 CET 2015 - lszhu@suse.de
 
 - remove ":" in target name when identifier is empty (bnc#932170) 

--- a/package/yast2-iscsi-lio-server.spec
+++ b/package/yast2-iscsi-lio-server.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-iscsi-lio-server
-Version:        3.1.15
+Version:        3.1.16
 Release:        0
 
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build

--- a/src/include/iscsi-lio-server/dialogs.rb
+++ b/src/include/iscsi-lio-server/dialogs.rb
@@ -48,6 +48,8 @@ module Yast
       Yast.include include_target, "iscsi-lio-server/helps.rb"
       Yast.include include_target, "iscsi-lio-server/widgets.rb"
 
+      $demo_mode=true
+
       # store current here
       @current_tab = "service"
 

--- a/src/include/iscsi-lio-server/widgets.rb
+++ b/src/include/iscsi-lio-server/widgets.rb
@@ -1589,7 +1589,14 @@ module Yast
       @changed_lun = {}
       Builtins.y2milestone("storeClient chg:%1", chg)
       IscsiLioData.UpdateConfig if chg
-
+    if $demo_mode
+    	cmd_set_demo_mode="lio_node --demomode" + " " + @curr_target + " "+ @curr_tpg.to_s
+    	cmd_disable_auth="lio_node --disableauth" + " " + @curr_target + " " + @curr_tpg.to_s
+    	cmd_disable_write_protection="echo 0 > /sys/kernel/config/target/iscsi/" + @curr_target + "/" + "tpgt_" + @curr_tpg.to_s + "/attrib/demo_mode_write_protect"
+    	SCR.Execute(path(".target.bash_output"), cmd_set_demo_mode)
+    	SCR.Execute(path(".target.bash_output"), cmd_disable_auth)
+    	SCR.Execute(path(".target.bash_output"), cmd_disable_write_protection)
+    end
       nil
     end
   end

--- a/src/modules/IscsiLioData.rb
+++ b/src/modules/IscsiLioData.rb
@@ -1261,6 +1261,12 @@ module Yast
     end
 
     def SetAuth(tgt, tpg, clnt, incoming, outgoing)
+    status= Convert.to_boolean(UI.QueryWidget(Id(:auth_none), :Value))
+	if status
+	$demo_mode=true
+	else
+	$demo_mode=false
+	end
       incoming = deep_copy(incoming)
       if incoming.empty?
         log_incoming = []


### PR DESCRIPTION
It is a bug fix for BNC#936990 - [yast2-iscsi-lio-server] malfunction when uncheck "Use Authentication" for a target.

When "No Authentication" checked, we should set demo_mode to the target, also we should disable chap authentication and disable write protection in demo mode