### PR TITLE
Replace SuSEFirewall by firewalld

### DIFF
--- a/package/yast2-iscsi-lio-server.changes
+++ b/package/yast2-iscsi-lio-server.changes
@@ -1,12 +1,19 @@
 -------------------------------------------------------------------
+Fri Jan 26 11:52:12 UTC 2018 - knut.anderssen@suse.com
+
+- Replace SuSEFirewall2 by firewalld (fate#323460)
+- 4.0.1
+
+-------------------------------------------------------------------
 Wed Dec 13 09:40:01 UTC 2017 - lszhu@suse.com
 
 - fate#319238 [yas2-iscsi-lio-server] refactor code to use
   targetcli-fb instead of lio-utils.
-- 4.0.0 
+- 4.0.0
 
 -------------------------------------------------------------------
-Tue May 16 10:09:07 UTC 2017 - lszhu@suse.com
+Tue May 16 10:09:07 UTC 2017 - lszhu@suse.de
+>>>>>>> Bump version & changelog.
 
 - fix bsc#1037819, add translation markers in adding LUN page
   Removed trailing ":" from labels.

--- a/package/yast2-iscsi-lio-server.changes
+++ b/package/yast2-iscsi-lio-server.changes
@@ -12,8 +12,7 @@ Wed Dec 13 09:40:01 UTC 2017 - lszhu@suse.com
 - 4.0.0
 
 -------------------------------------------------------------------
-Tue May 16 10:09:07 UTC 2017 - lszhu@suse.de
->>>>>>> Bump version & changelog.
+Tue May 16 10:09:07 UTC 2017 - lszhu@suse.com
 
 - fix bsc#1037819, add translation markers in adding LUN page
   Removed trailing ":" from labels.

--- a/package/yast2-iscsi-lio-server.spec
+++ b/package/yast2-iscsi-lio-server.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-iscsi-lio-server
-Version:        4.0.0
+Version:        4.0.1
 Release:        0
 
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build
@@ -32,10 +32,8 @@ Requires:       python-configshell-fb
 Requires:       python-rtslib-fb
 Requires:       targetcli-fb
 
-# network needs Wizard::OpenCancelOKDialog()
-#  function from yast2-2.18.2
-# Wizard::SetDesktopTitleAndIcon()
-Requires:       yast2 >= 2.21.22
+#Replace SuSEFirewall2 by firewalld
+Requires:       yast2 >= 4.0.39
 
 BuildArch:      noarch
 

--- a/src/include/iscsi-lio-server/UI_dialogs.rb
+++ b/src/include/iscsi-lio-server/UI_dialogs.rb
@@ -14,7 +14,6 @@ Yast.import 'CWMServiceStart'
 Yast.import 'Popup'
 Yast.import 'Wizard'
 Yast.import 'CWMFirewallInterfaces'
-Yast.import 'SuSEFirewall'
 Yast.import 'Service'
 Yast.import 'CWMServiceStart'
 Yast.import 'UI'
@@ -415,7 +414,7 @@ module Yast
       @service = Yast::SystemdService.find("sshd.service")
       @service_status = ::UI::ServiceStatus.new(@service, reload_flag: true, reload_flag_label: :restart)
       @firewall_widget = ::CWM::WrapperWidget.new(
-          CWMFirewallInterfaces.CreateOpenFirewallWidget("services" => ["service:target"]),
+          CWMFirewallInterfaces.CreateOpenFirewallWidget("services" => ["iscsi-target"]),
           )
     end
 


### PR DESCRIPTION
- [Trello Card](https://trello.com/c/99OkErr6/1093-8-firewall-firewalld-is-the-new-susefirewall-cwm)
- It depends on some pending modifications in yast-yast2.
