### PR TITLE
Replace python2 requirements with python3 packages.

### DIFF
--- a/package/yast2-iscsi-lio-server.changes
+++ b/package/yast2-iscsi-lio-server.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Thu Feb  1 11:41:10 UTC 2018 - lszhu@suse.com
+
+- fate#319238
+  Replace targetcli-fb python2 requirements with python3 packages.
+- 4.0.3
+
+-------------------------------------------------------------------
 Tue Jan 30 13:50:53 UTC 2018 - lszhu@suse.com
 
 - fate#323460, fate#319238

--- a/package/yast2-iscsi-lio-server.spec
+++ b/package/yast2-iscsi-lio-server.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-iscsi-lio-server
-Version:        4.0.2
+Version:        4.0.3
 Release:        0
 
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build
@@ -28,9 +28,9 @@ BuildRequires:  yast2
 BuildRequires:  yast2-devtools >= 3.1.10
 BuildRequires:  rubygem(%rb_default_ruby_abi:rspec)
 BuildRequires:  rubygem(%rb_default_ruby_abi:yast-rake)
-Requires:       python-configshell-fb
-Requires:       python-rtslib-fb
-Requires:       targetcli-fb
+Requires:       python3-configshell-fb
+Requires:       python3-rtslib-fb
+Requires:       python3-targetcli-fb
 
 #Replace SuSEFirewall2 by firewalld
 Requires:       yast2 >= 4.0.39


### PR DESCRIPTION
Replace targetcli-fb and related python2 requirements with
python3 packages.