### PR TITLE
Handle error that user want to rm not created LUNs

### DIFF
--- a/package/yast2-iscsi-lio-server.changes
+++ b/package/yast2-iscsi-lio-server.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Fri Mar 23 07:24:02 UTC 2018 - lszhu@suse.com
+
+- Handle the case that users want to delete a LUNs which
+  are not created yet(LUNs have data structure in memory but
+  not execute command to create them).
+
+-------------------------------------------------------------------
 Thu Mar 22 06:11:48 UTC 2018 - lszhu@suse.com
 
 - bsc#1085421

--- a/package/yast2-iscsi-lio-server.changes
+++ b/package/yast2-iscsi-lio-server.changes
@@ -1,7 +1,8 @@
 -------------------------------------------------------------------
 Fri Mar 23 07:24:02 UTC 2018 - lszhu@suse.com
 
-- Handle the case that users want to delete a LUNs which
+- bsc#1086029
+  Handle the case that users want to delete a LUNs which
   are not created yet(LUNs have data structure in memory but
   not execute command to create them).
 

--- a/package/yast2-iscsi-lio-server.spec
+++ b/package/yast2-iscsi-lio-server.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-iscsi-lio-server
-Version:        4.0.5
+Version:        4.0.6
 Release:        0
 
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build

--- a/src/include/iscsi-lio-server/UI_dialogs.rb
+++ b/src/include/iscsi-lio-server/UI_dialogs.rb
@@ -2562,7 +2562,7 @@ class LUNTable < CWM::Table
       rescue Cheetah::ExecutionFailed => e
         if e.stderr != nil
           failed_storage += (lun[3] + "\n")
-          table_remove_lun_item(lun[0])
+          table_remove_lun(lun[3])
           update_table
           next
         end
@@ -2892,7 +2892,12 @@ class LUNsTableWidget < CWM::CustomWidget
           end
         end
       when :delete
-        lun = @lun_table.get_selected
+        lun_array = @lun_table.get_selected
+        lun = lun_array[0]
+        if lun[1] == -1
+          @lun_table.table_remove_lun(lun[3])
+          return nil
+        end
         cmd = "targetcli"
         p1 = "backstores/"
         if lun[4] == "file"


### PR DESCRIPTION
Handle the cases that users may want to delete some LUNs that
have data structure in memory but not executed command to create
them, that means, not existing LUNs