### PR TITLE
accept symlinks to block devices and files in dialogs (bsc#1123316)

### DIFF
--- a/package/yast2-iscsi-lio-server.changes
+++ b/package/yast2-iscsi-lio-server.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Wed Feb 20 12:55:07 UTC 2019 - snwint@suse.com
+
+- accept symlinks to block devices and files in dialogs (bsc#1123316)
+- 4.1.3
+
+-------------------------------------------------------------------
 Mon Dec 17 15:11:06 UTC 2018 - jlopez@suse.com
 
 - Hardening commands execution (part of bsc#1118291).

--- a/package/yast2-iscsi-lio-server.spec
+++ b/package/yast2-iscsi-lio-server.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-iscsi-lio-server
-Version:        4.1.2
+Version:        4.1.3
 Release:        0
 
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build

--- a/src/include/iscsi-lio-server/UI_dialogs.rb
+++ b/src/include/iscsi-lio-server/UI_dialogs.rb
@@ -2710,8 +2710,7 @@ class LUNPathEdit < CWM::CustomWidget
       @lun_path_input.value = nil
       return false
     end
-    file_type = File.ftype(file)
-    if (file_type != 'blockSpecial') && (file_type != 'file')
+    if !File.file?(file) && !File.blockdev?(file)
       Yast::Popup.Error(_('Please provide a normal file or a block device.'))
       @lun_path_input.value = nil
       return false
@@ -2727,8 +2726,7 @@ class LUNPathEdit < CWM::CustomWidget
     if !(File.exist?(file))
       return false
     end
-    file_type = File.ftype(file)
-    if (file_type != 'blockSpecial') && (file_type != 'file')
+    if !File.file?(file) && !File.blockdev?(file)
       return false
     end
     true
@@ -2883,7 +2881,7 @@ class LUNsTableWidget < CWM::CustomWidget
           lun_name = ret[1]
           file = ret[2]
           if !file.nil? && (File.exist?(file))
-            @lun_table.add_lun_item([rand(9999), lun_number, lun_name, file, File.ftype(file)])
+            @lun_table.add_lun_item([rand(9999), lun_number, lun_name, file, File.stat(file).ftype])
           end
         end
       when :delete


### PR DESCRIPTION
Ruby's File.ftype does not follow symlinks.