### PR TITLE
Fix textdomain

### DIFF
--- a/package/yast2-iscsi-lio-server.changes
+++ b/package/yast2-iscsi-lio-server.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Fri Jan 31 16:21:06 UTC 2020 - Ancor Gonzalez Sosa <ancor@suse.com>
+
+- Improve internationalization support (bsc#1162378).
+- 4.2.1
+
+-------------------------------------------------------------------
 Fri May 31 12:31:59 UTC 2019 - Stasiek Michalski <hellcp@mailbox.org>
 
 - Add metainfo (fate#319035)

--- a/package/yast2-iscsi-lio-server.spec
+++ b/package/yast2-iscsi-lio-server.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-iscsi-lio-server
-Version:        4.2.0
+Version:        4.2.1
 Release:        0
 Summary:        Configuration of iSCSI LIO target
 License:        GPL-2.0-only

--- a/src/include/iscsi-lio-server/UI_dialogs.rb
+++ b/src/include/iscsi-lio-server/UI_dialogs.rb
@@ -808,6 +808,7 @@ end
 
 class TargetIdentifierInput < CWM::InputField
   def initialize(str)
+    textdomain "iscsi-lio-server"
     @config = str.downcase
   end
 
@@ -891,6 +892,7 @@ end
 
 class IpSelectionComboBox < CWM::ComboBox
   def initialize
+    textdomain "iscsi-lio-server"
     @addr = generate_items
     @config = "0.0.0.0"
   end
@@ -1420,6 +1422,7 @@ end
 
 class AddLUNMappingDialog < CWM::Dialog
   def initialize
+    textdomain "iscsi-lio-server"
     @initiator_lun_num = InitiatorLUNNumInput.new(-1)
     @target_lun_num = TargetLUNNumInput.new(-1)
   end
@@ -1852,6 +1855,7 @@ end
 # This class used to edit initiator / target auth, not global
 class EditAuthDialog < CWM::Dialog
   def initialize(initiator_name, target_name, tpg)
+    textdomain "iscsi-lio-server"
     @edit_auth_widget = EditAuthWidget.new(initiator_name, target_name, tpg)
   end
 
@@ -2596,6 +2600,7 @@ end
 
 class LUNPathInput < CWM::InputField
   def initialize(str)
+    textdomain "iscsi-lio-server"
     @config = str
   end
 


### PR DESCRIPTION
QA detected some missing calls to `textdomain`, which resulted in some texts being displayed always in English.

See https://bugzilla.suse.com/show_bug.cgi?id=1162378

This adds the missing calls.

Tested manually using `Y2STRICTTEXTDOMAIN=1`