### PR TITLE
Use :restart as the default service action when active

### DIFF
--- a/package/yast2-iscsi-lio-server.changes
+++ b/package/yast2-iscsi-lio-server.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Wed Mar 11 09:13:07 UTC 2020 - Knut Anderssen <kanderssen@suse.com>
+
+- Propose to restart the targetcli service as the default action
+  when it is active (bsc#1165638)
+- 4.1.7
+
+-------------------------------------------------------------------
 Mon Mar 04 10:34:15 CET 2019 - aschnell@suse.com
 
 - added error handling for loading discovery authentication data

--- a/package/yast2-iscsi-lio-server.spec
+++ b/package/yast2-iscsi-lio-server.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-iscsi-lio-server
-Version:        4.1.6
+Version:        4.1.7
 Release:        0
 
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build

--- a/src/include/iscsi-lio-server/UI_dialogs.rb
+++ b/src/include/iscsi-lio-server/UI_dialogs.rb
@@ -413,6 +413,7 @@ module Yast
       self.initial = true
       @service = Yast2::SystemService.find("targetcli")
       @service_widget = ::CWM::ServiceWidget.new(@service)
+      @service_widget.default_action = :restart if @service.currently_active?
       @firewall_widget = ::CWM::WrapperWidget.new(
         CWMFirewallInterfaces.CreateOpenFirewallWidget("services" => ["iscsi-target"]),
       )


### PR DESCRIPTION
## Problem

When the new service widget was [introduced](https://trello.com/c/uAe4i9Ru/107-5-fate319428-allow-socket-activation-widget), the default action when writing the modified configuration was to `keep the current state`, that basically means **do not touch the service**.

That was not the default action in **SLE-12** for some of the modules that use the new service widget, at least it is not the case of this module.

For that reason, in previous sprint it was agreed to change the default action, using `reload` (when supported) or `restart` when the service was **active** and `keep_the_current_state` when it was **inactive**. (see https://github.com/yast/yast-yast2/pull/1001)

The targetcli service supports the `reload` action and therefore it is the **proposed default action** which is not exactly the same that is proposed in SLE-15-GA (it is [restart](https://github.com/yast/yast-iscsi-lio-server/blob/SLE-15-GA/src/include/iscsi-lio-server/UI_dialogs.rb#L415))

- https://trello.com/c/0iBBEqsF/1635-8-check-all-listed-modules-whether-the-new-servicewidget-default-action-is-the-correct-one
- https://bugzilla.suse.com/show_bug.cgi?id=1165638

## Solution

- Propose **restart** as the default service widget action in case the service is running.

## Screenshots


| SLE-15-GA | SLE-15-SP2 (Before) | SLE-15-SP2 (with restart)
|--------|----|----|
| ![iscsi-lio-server_ga](https://user-images.githubusercontent.com/1691872/43568798-818c31b8-962d-11e8-9325-12996b392cde.png) | ![ReloadSLE-15-SP2](https://user-images.githubusercontent.com/7056681/76400431-34209f80-6378-11ea-9063-589d14f88327.png) | ![RestartIfActiveSLE-15-SP2](https://user-images.githubusercontent.com/7056681/76400433-34b93600-6378-11ea-85d5-2f6fabc0b771.png) |