### PR TITLE
Fix discovery auth status

### DIFF
--- a/package/yast2-iscsi-lio-server.changes
+++ b/package/yast2-iscsi-lio-server.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Wed Apr  8 15:41:52 UTC 2020 - Knut Anderssen <kanderssen@suse.com>
+
+- Fix check of discovery authentication status, enabling or
+  disabling it correctly according to user selection (bsc#1166707)
+- 4.2.4
+
+-------------------------------------------------------------------
 Wed Mar 11 15:45:38 UTC 2020 - Josef Reidinger <jreidinger@suse.com>
 
 - Fix usability issues in global tab (bsc#1127505)

--- a/package/yast2-iscsi-lio-server.spec
+++ b/package/yast2-iscsi-lio-server.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-iscsi-lio-server
-Version:        4.2.3
+Version:        4.2.4
 Release:        0
 Summary:        Configuration of iSCSI LIO target
 License:        GPL-2.0-only

--- a/src/clients/iscsi-lio-server.rb
+++ b/src/clients/iscsi-lio-server.rb
@@ -75,8 +75,8 @@ module Yast
         mutual_password = $discovery_auth.fetch_mutual_password
         cmd = '/usr/bin/targetcli'
         p1 = "iscsi/ set discovery_auth "
-        # status == false means "No discovery auth" is not checked, means we need enable discovery auth
-        if !status
+        # status == true means "Discovery auth" is checked, means we need enable discovery auth
+        if status
           unless userid.empty?
             p1 += ("userid=" + userid + " ")
           end


### PR DESCRIPTION
## Problem

Discovery authentication is enabled although the user does not set it because of the changes introduced in #100 which switched the checked box meaning from `disabling` to `enabling` it explicitly.

- https://bugzilla.suse.com/show_bug.cgi?id=1168856

## Solution

Fix the check of the discovery authentication status enabling or disabling it correctly

