### PR TITLE
Write service after saving state

### DIFF
--- a/package/yast2-iscsi-lio-server.changes
+++ b/package/yast2-iscsi-lio-server.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Fri Apr 10 09:33:34 UTC 2020 - Knut Anderssen <kanderssen@suse.com>
+
+- Save service changes after writing the target config and not
+  before preventing the lost of target changes (bsc#1166707)
+- 4.2.5
+
+-------------------------------------------------------------------
 Wed Apr  8 15:41:52 UTC 2020 - Knut Anderssen <kanderssen@suse.com>
 
 - Fix check of discovery authentication status, enabling or

--- a/package/yast2-iscsi-lio-server.spec
+++ b/package/yast2-iscsi-lio-server.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-iscsi-lio-server
-Version:        4.2.4
+Version:        4.2.5
 Release:        0
 Summary:        Configuration of iSCSI LIO target
 License:        GPL-2.0-only

--- a/src/clients/iscsi-lio-server.rb
+++ b/src/clients/iscsi-lio-server.rb
@@ -67,7 +67,6 @@ module Yast
       ret = CWM.show(contents, caption: _("Yast iSCSI Targets"),next_button: _("Finish"))
       if ret == :next
         firewalld.write
-        service_tab.write
         status = $discovery_auth.fetch_status
         userid = $discovery_auth.fetch_userid
         password = $discovery_auth.fetch_password
@@ -103,6 +102,7 @@ module Yast
           end
         end
         $global_data.execute_exit_commands
+        service_tab.write
       end
       Yast::Wizard.CloseDialog
     end


### PR DESCRIPTION
## Problem

Default service action is to restart the service when it is running (see https://github.com/yast/yast-iscsi-lio-server/pull/98). 

Thus, if the user change some target config, it is lost because the service is restarted before saving it.

- https://trello.com/c/ZrHSd0T7/1774-sles15-sp2-p2-1166707-build-1551-error-iscsiadm-login-failure-to-authenticate-with-target
- https://bugzilla.suse.com/show_bug.cgi?id=1166707

## Solution

- Apply service changes after saving the target config.