### PR TITLE
Do not check for "python3-targetcli-fb" at runtime (bsc#1185199)

### DIFF
--- a/package/yast2-iscsi-lio-server.changes
+++ b/package/yast2-iscsi-lio-server.changes
@@ -1,4 +1,14 @@
 -------------------------------------------------------------------
+Fri Apr 23 07:58:36 UTC 2021 - Ladislav Slezák <lslezak@suse.cz>
+
+- Removed check for "python3-targetcli-fb" package at runtime
+  (bsc#1185199)
+  - Tumbleweed does not include that package names, only
+    python36-targetcli-fb and python38-targetcli-fb
+  - The package is already installed via RPM dependencies
+- 4.4.1
+
+-------------------------------------------------------------------
 Tue Apr 20 13:51:55 UTC 2021 - Ladislav Slezák <lslezak@suse.cz>
 
 - 4.4.0

--- a/package/yast2-iscsi-lio-server.spec
+++ b/package/yast2-iscsi-lio-server.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-iscsi-lio-server
-Version:        4.4.0
+Version:        4.4.1
 Release:        0
 Summary:        Configuration of iSCSI LIO target
 License:        GPL-2.0-only

--- a/src/clients/iscsi-lio-server.rb
+++ b/src/clients/iscsi-lio-server.rb
@@ -23,33 +23,6 @@ module Yast
       Confirm.MustBeRoot
     end
 
-    def installed_packages
-      if !PackageSystem.PackageInstalled("python3-targetcli-fb")
-        confirm = Popup.AnyQuestionRichText(
-          "",
-            _("Yast iscsi-lio-server can't run without installing targetcli-fb package. Do you want to install?"),
-            40,
-            10,
-            Label.InstallButton,
-            Label.CancelButton,
-            :focus_yes
-        )
-
-        if confirm
-          PackageSystem.DoInstall(["python3-targetcli-fb"])
-          if PackageSystem.PackageInstalled("python3-targetcli-fb")
-            return true
-          else
-            err_msg = _("Failed to install targetcli-fb and related packages.")
-            Yast::Popup.Error(err_msg)
-            false
-          end
-        end
-      else
-        true
-      end
-    end
-
     def firewalld
       Y2Firewall::Firewalld.instance
     end
@@ -114,11 +87,9 @@ ret = iscsi_target_server.is_root
 if !ret
   exit
 end
-ret = iscsi_target_server.installed_packages
-if ret
-  $target_data = TargetData.new
-  $global_data = Global.new
-  $global_data.execute_init_commands
-  $discovery_auth = DiscoveryAuth.new
-  iscsi_target_server.run
-end
+
+$target_data = TargetData.new
+$global_data = Global.new
+$global_data.execute_init_commands
+$discovery_auth = DiscoveryAuth.new
+iscsi_target_server.run


### PR DESCRIPTION
- https://bugzilla.suse.com/show_bug.cgi?id=1185199

### Problem 1

- It checks whether the `python3-targetcli-fb` package is installed and asks to install it
- Unfortunately there is no such package in Tumbleweed, there are `python36-targetcli-fb` and `python38-targetcli-fb`

### Problem 2

- This check is actually not need at all, the package is already installed together with `yast2-iscsi-lio-server` via RPM dependencies from *.spec ([here](https://github.com/yast/yast-iscsi-lio-server/blob/9663e4ff0d8a4cef75e9b5044aca20caff9e43b8/package/yast2-iscsi-lio-server.spec#L38))
- Moreover it correctly installs the version for the default Python

```
# zypper in yast2-iscsi-lio-server
Loading repository data...
Reading installed packages...
Resolving package dependencies...

The following 7 NEW packages are going to be installed:
  python-rtslib-fb-common python38-configshell-fb python38-rtslib-fb
  python38-targetcli-fb python38-urwid targetcli-fb-common
  yast2-iscsi-lio-server

7 new packages to install.
Overall download size: 753.4 KiB. Already cached: 0 B. After the operation,
additional 4.1 MiB will be used.
```

### Solution

- Lets remove the runtime package check completely, it is not need and does not work well in Tumbleweed

### Testing

- Tested manually, the module still starts properly :smiley: 