### PR TITLE
Add missing bugzilla reference to latest changelog entry

### DIFF
--- a/package/yast2-iscsi-lio-server.changes
+++ b/package/yast2-iscsi-lio-server.changes
@@ -1,7 +1,7 @@
 -------------------------------------------------------------------
 Fri Dec  2 22:01:33 UTC 2022 - Kristijan Velkovski <me@krisfremen.com>
 
-- Fix misspellings and syntax of UI text
+- Fix misspellings and syntax of UI text (bsc#1206409)
 - 4.5.1
 
 -------------------------------------------------------------------


### PR DESCRIPTION
## Problem

A missing bugzilla reference in the changelog entry when submitting #111 

## Solution

Create the bugzilla entry and fix the changelog referencing it.